### PR TITLE
Legg til journalpostid i hentsoknad for tittelmatching

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -29,7 +29,7 @@ jobs:
         env:
           TESTCONTAINERS_RYUK_DISABLED: true
       - name: Build and Publish Docker image
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/legg-til-journalpostid-i-hentsoknad-for-tittelmatching'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -40,7 +40,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/legg-til-journalpostid-i-hentsoknad-for-tittelmatching'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -29,7 +29,7 @@ jobs:
         env:
           TESTCONTAINERS_RYUK_DISABLED: true
       - name: Build and Publish Docker image
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/legg-til-journalpostid-i-hentsoknad-for-tittelmatching'
+        if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -40,7 +40,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     needs: build
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/legg-til-journalpostid-i-hentsoknad-for-tittelmatching'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -49,15 +49,15 @@ jobs:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: nais/nais-dev.yaml,nais/alerts-dev.yaml
-#  deploy-prod:
-#    name: Deploy to Production
-#    needs: [build, deploy-dev]
-#    if: github.ref == 'refs/heads/main'
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: nais/deploy/actions/deploy@v1
-#        env:
-#          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-#          CLUSTER: prod-gcp
-#          RESOURCE: nais/nais-prod.yaml,nais/alerts-prod.yaml
+  deploy-prod:
+    name: Deploy to Production
+    needs: [build, deploy-dev]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: nais/nais-prod.yaml,nais/alerts-prod.yaml

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -49,15 +49,15 @@ jobs:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: nais/nais-dev.yaml,nais/alerts-dev.yaml
-  deploy-prod:
-    name: Deploy to Production
-    needs: [build, deploy-dev]
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: nais/nais-prod.yaml,nais/alerts-prod.yaml
+#  deploy-prod:
+#    name: Deploy to Production
+#    needs: [build, deploy-dev]
+#    if: github.ref == 'refs/heads/main'
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: nais/deploy/actions/deploy@v1
+#        env:
+#          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+#          CLUSTER: prod-gcp
+#          RESOURCE: nais/nais-prod.yaml,nais/alerts-prod.yaml

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/db/db/SøknadStore.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/db/db/SøknadStore.kt
@@ -572,7 +572,7 @@ internal class SøknadStorePostgres(private val ds: DataSource) : SøknadStore {
         if (uid == null) return null
         try {
             return UUID.fromString(uid)
-        } catch (e: Exception) {
+        } catch (e: IllegalArgumentException) {
             return null
         }
     }

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/db/db/SøknadStore.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/db/db/SøknadStore.kt
@@ -569,11 +569,11 @@ internal class SøknadStorePostgres(private val ds: DataSource) : SøknadStore {
     private fun soknadToJsonString(soknad: JsonNode): String = objectMapper.writeValueAsString(soknad)
 
     private fun uuidFromStringOrNull(uid: String?): UUID? {
-        if (uid == null) return null
-        try {
-            return UUID.fromString(uid)
-        } catch (e: IllegalArgumentException) {
-            return null
+        if (uid != null) {
+            try {
+                return UUID.fromString(uid)
+            } catch (e: IllegalArgumentException) {}
         }
+        return null
     }
 }

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/db/db/SøknadStore.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/db/db/SøknadStore.kt
@@ -103,7 +103,7 @@ internal class SøknadStorePostgres(private val ds: DataSource) : SøknadStore {
     override fun hentSoknad(soknadsId: UUID): SøknadForBruker? {
         @Language("PostgreSQL") val statement =
             """
-                SELECT soknad.SOKNADS_ID, soknad.DATA, soknad.CREATED, soknad.KOMMUNENAVN, soknad.FNR_BRUKER, soknad.UPDATED, soknad.ER_DIGITAL, status.STATUS, 
+                SELECT soknad.SOKNADS_ID, soknad.JOURNALPOSTID, soknad.DATA, soknad.CREATED, soknad.KOMMUNENAVN, soknad.FNR_BRUKER, soknad.UPDATED, soknad.ER_DIGITAL, status.STATUS, 
                 (CASE WHEN EXISTS (
                     SELECT 1 FROM V1_STATUS WHERE SOKNADS_ID = soknad.SOKNADS_ID AND STATUS IN  ('GODKJENT_MED_FULLMAKT')
                 ) THEN true ELSE false END) as fullmakt
@@ -127,6 +127,7 @@ internal class SøknadStorePostgres(private val ds: DataSource) : SøknadStore {
                         if (status.isSlettetEllerUtløpt() || !it.boolean("ER_DIGITAL")) {
                             SøknadForBruker.newEmptySøknad(
                                 søknadId = UUID.fromString(it.string("SOKNADS_ID")),
+                                journalpostId = uuidFromStringOrNull(it.string("JOURNALPOSTID")),
                                 status = Status.valueOf(it.string("STATUS")),
                                 fullmakt = it.boolean("fullmakt"),
                                 datoOpprettet = it.sqlTimestamp("created"),
@@ -142,6 +143,7 @@ internal class SøknadStorePostgres(private val ds: DataSource) : SøknadStore {
                         } else {
                             SøknadForBruker.new(
                                 søknadId = UUID.fromString(it.string("SOKNADS_ID")),
+                                journalpostId = uuidFromStringOrNull(it.string("JOURNALPOSTID")),
                                 status = Status.valueOf(it.string("STATUS")),
                                 fullmakt = it.boolean("fullmakt"),
                                 datoOpprettet = it.sqlTimestamp("created"),
@@ -339,7 +341,7 @@ internal class SøknadStorePostgres(private val ds: DataSource) : SøknadStore {
     override fun hentSoknaderForBruker(fnrBruker: String): List<SoknadMedStatus> {
         @Language("PostgreSQL") val statement =
             """
-                SELECT soknad.SOKNADS_ID, soknad.CREATED, soknad.UPDATED, soknad.DATA, soknad.ER_DIGITAL, status.STATUS,
+                SELECT soknad.SOKNADS_ID, soknad.JOURNALPOSTID, soknad.CREATED, soknad.UPDATED, soknad.DATA, soknad.ER_DIGITAL, status.STATUS,
                 (CASE WHEN EXISTS (
                     SELECT 1 FROM V1_STATUS WHERE SOKNADS_ID = soknad.SOKNADS_ID AND STATUS IN  ('GODKJENT_MED_FULLMAKT')
                 ) THEN true ELSE false END) as fullmakt
@@ -364,6 +366,7 @@ internal class SøknadStorePostgres(private val ds: DataSource) : SøknadStore {
                         if (status.isSlettetEllerUtløpt() || !it.boolean("ER_DIGITAL")) {
                             SoknadMedStatus.newSøknadUtenFormidlernavn(
                                 soknadId = UUID.fromString(it.string("SOKNADS_ID")),
+                                journalpostId = uuidFromStringOrNull(it.string("JOURNALPOSTID")),
                                 status = Status.valueOf(it.string("STATUS")),
                                 fullmakt = it.boolean("fullmakt"),
                                 datoOpprettet = it.sqlTimestamp("created"),
@@ -376,6 +379,7 @@ internal class SøknadStorePostgres(private val ds: DataSource) : SøknadStore {
                         } else {
                             SoknadMedStatus.newSøknadMedFormidlernavn(
                                 soknadId = UUID.fromString(it.string("SOKNADS_ID")),
+                                journalpostId = uuidFromStringOrNull(it.string("JOURNALPOSTID")),
                                 status = Status.valueOf(it.string("STATUS")),
                                 fullmakt = it.boolean("fullmakt"),
                                 datoOpprettet = it.sqlTimestamp("created"),
@@ -563,4 +567,12 @@ internal class SøknadStorePostgres(private val ds: DataSource) : SøknadStore {
     }
 
     private fun soknadToJsonString(soknad: JsonNode): String = objectMapper.writeValueAsString(soknad)
+
+    private fun uuidFromStringOrNull(uid: String): UUID? {
+        try {
+            return UUID.fromString(uid)
+        } catch (e: Exception) {
+            return null
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/db/db/SøknadStore.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/db/db/SøknadStore.kt
@@ -127,7 +127,7 @@ internal class SøknadStorePostgres(private val ds: DataSource) : SøknadStore {
                         if (status.isSlettetEllerUtløpt() || !it.boolean("ER_DIGITAL")) {
                             SøknadForBruker.newEmptySøknad(
                                 søknadId = UUID.fromString(it.string("SOKNADS_ID")),
-                                journalpostId = uuidFromStringOrNull(it.string("JOURNALPOSTID")),
+                                journalpostId = uuidFromStringOrNull(it.stringOrNull("JOURNALPOSTID")),
                                 status = Status.valueOf(it.string("STATUS")),
                                 fullmakt = it.boolean("fullmakt"),
                                 datoOpprettet = it.sqlTimestamp("created"),
@@ -143,7 +143,7 @@ internal class SøknadStorePostgres(private val ds: DataSource) : SøknadStore {
                         } else {
                             SøknadForBruker.new(
                                 søknadId = UUID.fromString(it.string("SOKNADS_ID")),
-                                journalpostId = uuidFromStringOrNull(it.string("JOURNALPOSTID")),
+                                journalpostId = uuidFromStringOrNull(it.stringOrNull("JOURNALPOSTID")),
                                 status = Status.valueOf(it.string("STATUS")),
                                 fullmakt = it.boolean("fullmakt"),
                                 datoOpprettet = it.sqlTimestamp("created"),
@@ -366,7 +366,7 @@ internal class SøknadStorePostgres(private val ds: DataSource) : SøknadStore {
                         if (status.isSlettetEllerUtløpt() || !it.boolean("ER_DIGITAL")) {
                             SoknadMedStatus.newSøknadUtenFormidlernavn(
                                 soknadId = UUID.fromString(it.string("SOKNADS_ID")),
-                                journalpostId = uuidFromStringOrNull(it.string("JOURNALPOSTID")),
+                                journalpostId = uuidFromStringOrNull(it.stringOrNull("JOURNALPOSTID")),
                                 status = Status.valueOf(it.string("STATUS")),
                                 fullmakt = it.boolean("fullmakt"),
                                 datoOpprettet = it.sqlTimestamp("created"),
@@ -379,7 +379,7 @@ internal class SøknadStorePostgres(private val ds: DataSource) : SøknadStore {
                         } else {
                             SoknadMedStatus.newSøknadMedFormidlernavn(
                                 soknadId = UUID.fromString(it.string("SOKNADS_ID")),
-                                journalpostId = uuidFromStringOrNull(it.string("JOURNALPOSTID")),
+                                journalpostId = uuidFromStringOrNull(it.stringOrNull("JOURNALPOSTID")),
                                 status = Status.valueOf(it.string("STATUS")),
                                 fullmakt = it.boolean("fullmakt"),
                                 datoOpprettet = it.sqlTimestamp("created"),
@@ -568,7 +568,8 @@ internal class SøknadStorePostgres(private val ds: DataSource) : SøknadStore {
 
     private fun soknadToJsonString(soknad: JsonNode): String = objectMapper.writeValueAsString(soknad)
 
-    private fun uuidFromStringOrNull(uid: String): UUID? {
+    private fun uuidFromStringOrNull(uid: String?): UUID? {
+        if (uid == null) return null
         try {
             return UUID.fromString(uid)
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SoknadMedStatus.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SoknadMedStatus.kt
@@ -6,6 +6,7 @@ import java.util.UUID
 
 class SoknadMedStatus private constructor(
     val soknadId: UUID,
+    val journalpostId: UUID?,
     val datoOpprettet: Date,
     val datoOppdatert: Date,
     val status: Status,
@@ -14,11 +15,11 @@ class SoknadMedStatus private constructor(
     val er_digital: Boolean
 ) {
     companion object {
-        fun newSøknadUtenFormidlernavn(soknadId: UUID, datoOpprettet: Date, datoOppdatert: Date, status: Status, fullmakt: Boolean, er_digital: Boolean) =
-            SoknadMedStatus(soknadId, datoOpprettet, datoOppdatert, status, fullmakt, null, er_digital)
+        fun newSøknadUtenFormidlernavn(soknadId: UUID, journalpostId: UUID?, datoOpprettet: Date, datoOppdatert: Date, status: Status, fullmakt: Boolean, er_digital: Boolean) =
+            SoknadMedStatus(soknadId, journalpostId, datoOpprettet, datoOppdatert, status, fullmakt, null, er_digital)
 
-        fun newSøknadMedFormidlernavn(soknadId: UUID, datoOpprettet: Date, datoOppdatert: Date, status: Status, fullmakt: Boolean, søknad: JsonNode, er_digital: Boolean) =
-            SoknadMedStatus(soknadId, datoOpprettet, datoOppdatert, status, fullmakt, formidlerNavn(søknad), er_digital)
+        fun newSøknadMedFormidlernavn(soknadId: UUID, journalpostId: UUID?, datoOpprettet: Date, datoOppdatert: Date, status: Status, fullmakt: Boolean, søknad: JsonNode, er_digital: Boolean) =
+            SoknadMedStatus(soknadId, journalpostId, datoOpprettet, datoOppdatert, status, fullmakt, formidlerNavn(søknad), er_digital)
     }
 }
 

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SøknadForBruker.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SøknadForBruker.kt
@@ -6,6 +6,7 @@ import java.util.UUID
 
 class SøknadForBruker private constructor(
     val søknadId: UUID,
+    val journalpostId: UUID?,
     val datoOpprettet: Date,
     var datoOppdatert: Date,
     val status: Status,
@@ -20,6 +21,7 @@ class SøknadForBruker private constructor(
     companion object {
         fun new(
             søknadId: UUID,
+            journalpostId: UUID?,
             datoOpprettet: Date,
             datoOppdatert: Date,
             søknad: JsonNode,
@@ -33,6 +35,7 @@ class SøknadForBruker private constructor(
         ) =
             SøknadForBruker(
                 søknadId,
+                journalpostId,
                 datoOpprettet,
                 datoOppdatert,
                 status,
@@ -46,6 +49,7 @@ class SøknadForBruker private constructor(
 
         fun newEmptySøknad(
             søknadId: UUID,
+            journalpostId: UUID?,
             datoOpprettet: Date,
             datoOppdatert: Date,
             status: Status,
@@ -55,7 +59,7 @@ class SøknadForBruker private constructor(
             ordrelinjer: List<SøknadForBrukerOrdrelinje>,
             fagsakId: String?,
         ) =
-            SøknadForBruker(søknadId, datoOpprettet, datoOppdatert, status, fullmakt, fnrBruker, null, er_digital, ordrelinjer, fagsakId)
+            SøknadForBruker(søknadId, journalpostId, datoOpprettet, datoOppdatert, status, fullmakt, fnrBruker, null, er_digital, ordrelinjer, fagsakId)
     }
 }
 


### PR DESCRIPTION
Legger her til journalpostId i svarene for apiene hentSoknad og hentSoknaderForBruker. Dette skal brukes i frontend til å matche journalpost fra safselvbetjening for å hente ut dokumenttittler slik at vi i søknadsoversikten kan feks. vise "Søknad om hjelpemidler - Syn" ol. i stede for at alle heter det samme nedover listen.