### PR TITLE
spesifiser JDK12 for snyk/gradle GitHub Action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Run Snyk to check for vulnerabilities
-      uses: snyk/actions/gradle@master
+      uses: snyk/actions/gradle-jdk12@master
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:


### PR DESCRIPTION
Re-run av action som tidligare har kjørt ok: 
https://github.com/navikt/hm-soknadsbehandling-db/runs/3841152118?check_suite_focus=true

Er ikkje 100% sikker, men virkar som problemet var at `snyk/actions/gradle@master` har gått over på JVM 17