### PR TITLE
Returner årsak for antall

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - ers-kabin
-      - nye-felter-kalenderapp
+      - arsakForAntall
 
 env:
   IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SøknadForBruker.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SøknadForBruker.kt
@@ -257,7 +257,7 @@ private fun hjelpemidler(søknad: JsonNode): List<Hjelpemiddel> {
 private fun arsakForAntall(hjelpemiddel: JsonNode): String? {
    val arsak = hjelpemiddel["arsakForAntall"]?.let {
        when (hjelpemiddel["arsakForAntall"].textValue()) {
-           // Legacy-fix for fra da det ble lagret faktiske verdier i databasen, og ikke enums
+           // Returner enums så det blir lettere å legge inn translations
            "Behov i flere etasjer" -> "BEHOV_I_FLERE_ETASJER"
            "Behov i flere rom" -> "BEHOV_I_FLERE_ROM"
            "Behov både innendørs og utendørs" -> "BEHOV_INNENDØRS_OG_UTENDØRS"

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SøknadForBruker.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SøknadForBruker.kt
@@ -231,6 +231,7 @@ private fun hjelpemidler(søknad: JsonNode): List<Hjelpemiddel> {
         val hjelpemiddel = Hjelpemiddel(
             antall = it["antall"].intValue(),
             arsakForAntall = arsakForAntall(it),
+            arsakForAntallBegrunnelse = it["arsakForAntallBegrunnelse"]?.textValue(),
             beskrivelse = it["beskrivelse"].textValue(),
             hjelpemiddelkategori = it["hjelpemiddelkategori"].textValue(),
             hmsNr = it["hmsNr"].textValue(),
@@ -254,7 +255,7 @@ private fun hjelpemidler(søknad: JsonNode): List<Hjelpemiddel> {
 }
 
 private fun arsakForAntall(hjelpemiddel: JsonNode): String? {
-   val arsak = hjelpemiddel["arsakForAntallBegrunnelse"]?.textValue() ?: hjelpemiddel["arsakForAntall"]?.let {
+   val arsak = hjelpemiddel["arsakForAntall"]?.let {
        when (hjelpemiddel["arsakForAntall"].textValue()) {
            // Legacy-fix for fra da det ble lagret faktiske verdier i databasen, og ikke enums
            "Behov i flere etasjer" -> "BEHOV_I_FLERE_ETASJER"
@@ -266,7 +267,7 @@ private fun arsakForAntall(hjelpemiddel: JsonNode): String? {
            "Annet behov" -> "ANNET_BEHOV"
            else -> "UKJENT_ÅRSAK"
        }
-   } ?: hjelpemiddel["arsakForAntallValg"]?.textValue()
+   }
 
     return arsak
 }
@@ -432,6 +433,7 @@ class Oppfolgingsansvarlig(
 class Hjelpemiddel(
     val antall: Int,
     val arsakForAntall: String?,
+    val arsakForAntallBegrunnelse: String?,
     val beskrivelse: String,
     val hjelpemiddelkategori: String,
     val hmsNr: String,

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SøknadForBruker.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SøknadForBruker.kt
@@ -230,6 +230,7 @@ private fun hjelpemidler(søknad: JsonNode): List<Hjelpemiddel> {
     søknad["soknad"]["hjelpemidler"]["hjelpemiddelListe"].forEach {
         val hjelpemiddel = Hjelpemiddel(
             antall = it["antall"].intValue(),
+            arsakForAntall = arsakForAntall(it),
             beskrivelse = it["beskrivelse"].textValue(),
             hjelpemiddelkategori = it["hjelpemiddelkategori"].textValue(),
             hmsNr = it["hmsNr"].textValue(),
@@ -250,6 +251,24 @@ private fun hjelpemidler(søknad: JsonNode): List<Hjelpemiddel> {
         hjelpemidler.add(hjelpemiddel)
     }
     return hjelpemidler
+}
+
+private fun arsakForAntall(hjelpemiddel: JsonNode): String? {
+   val arsak = hjelpemiddel["arsakForAntallBegrunnelse"]?.textValue() ?: hjelpemiddel["arsakForAntall"]?.let {
+       when (hjelpemiddel["arsakForAntall"].textValue()) {
+           // Legacy-fix for fra da det ble lagret faktiske verdier i databasen, og ikke enums
+           "Behov i flere etasjer" -> "BEHOV_I_FLERE_ETASJER"
+           "Behov i flere rom" -> "BEHOV_I_FLERE_ROM"
+           "Behov både innendørs og utendørs" -> "BEHOV_INNENDØRS_OG_UTENDØRS"
+           "Behov for pute til flere rullestoler eller sitteenheter" -> "BEHOV_FOR_FLERE_PUTER_FOR_RULLESTOL"
+           "Behov for jevnlig vask eller vedlikehold" -> "BEHOV_FOR_JEVNLIG_VASK_ELLER_VEDLIKEHOLD"
+           "Bruker har to hjem" -> "BRUKER_HAR_TO_HJEM"
+           "Annet behov" -> "ANNET_BEHOV"
+           else -> "UKJENT_ÅRSAK"
+       }
+   } ?: hjelpemiddel["arsakForAntallValg"]?.textValue()
+
+    return arsak
 }
 
 private fun vilkaar(hjelpemiddel: JsonNode): List<HjelpemiddelVilkar> {
@@ -412,6 +431,7 @@ class Oppfolgingsansvarlig(
 
 class Hjelpemiddel(
     val antall: Int,
+    val arsakForAntall: String?,
     val beskrivelse: String,
     val hjelpemiddelkategori: String,
     val hmsNr: String,


### PR DESCRIPTION
Vi sender idag inn årsak for antall som en ren string-verdi fra søknaden. Det er litt klønete mtp translations, så de burde ideellt sett blitt sendt inn som enums. Disse verdiene er nå lagret i databasen uansett, så selv om vi etterhvert endrer at søknaden sender enum-verdier, må vi gjøre om de gamle string-verdiene til enums, som da denne PRen gjør.