### PR TITLE
Respekter checked vilkar

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - main
-      - INNSENDT_FULLMAKT_IKKE_PÅKREVD
-      - ganghjelpemidler
+      - respekter-checked-vilkar
 
 jobs:
   build:

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SøknadForBruker.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SøknadForBruker.kt
@@ -336,7 +336,7 @@ private fun vilkaar(hjelpemiddel: JsonNode): List<HjelpemiddelVilkar> {
     hjelpemiddel["vilkarliste"]?.filter { it["checked"].asBoolean() }?.forEach {
         vilkarListe.add(
             HjelpemiddelVilkar(
-                vilkaartekst = it["vilkartekst"].textValue(),
+                vilkaarTekst = it["vilkartekst"].textValue(),
                 tilleggsinfo = it["tilleggsinfo"]?.textValue()
             )
         )
@@ -878,7 +878,7 @@ enum class KontaktpersonType {
 }
 
 class HjelpemiddelVilkar(
-    val vilkaartekst: String,
+    val vilkaarTekst: String,
     val tilleggsinfo: String?,
 )
 

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SøknadForBruker.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SøknadForBruker.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.treeToValue
 import no.nav.hjelpemidler.soknad.db.JacksonMapper.Companion.objectMapper
 import no.nav.hjelpemidler.soknad.db.client.hmdb.hentproduktermedhmsnrs.Produkt
-import no.nav.hjelpemidler.soknad.db.domain.kommune_api.HjmBruksarena
 import java.util.Date
 import java.util.UUID
 
@@ -334,7 +333,7 @@ private fun arsakForAntall(hjelpemiddel: JsonNode): String? {
 
 private fun vilkaar(hjelpemiddel: JsonNode): List<HjelpemiddelVilkar> {
     val vilkarListe = mutableListOf<HjelpemiddelVilkar>()
-    hjelpemiddel["vilkarliste"]?.forEach {
+    hjelpemiddel["vilkarliste"]?.filter { it["checked"].asBoolean() }?.forEach {
         vilkarListe.add(
             HjelpemiddelVilkar(
                 vilkaarTekst = it["vilkartekst"].textValue(),

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SøknadForBruker.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SøknadForBruker.kt
@@ -336,8 +336,8 @@ private fun vilkaar(hjelpemiddel: JsonNode): List<HjelpemiddelVilkar> {
     hjelpemiddel["vilkarliste"]?.filter { it["checked"].asBoolean() }?.forEach {
         vilkarListe.add(
             HjelpemiddelVilkar(
-                vilkaarTekst = it["vilkartekst"].textValue(),
-                tilleggsInfo = it["tilleggsinfo"]?.textValue()
+                vilkaartekst = it["vilkartekst"].textValue(),
+                tilleggsinfo = it["tilleggsinfo"]?.textValue()
             )
         )
     }
@@ -878,8 +878,8 @@ enum class KontaktpersonType {
 }
 
 class HjelpemiddelVilkar(
-    val vilkaarTekst: String,
-    val tilleggsInfo: String?,
+    val vilkaartekst: String,
+    val tilleggsinfo: String?,
 )
 
 class Tilbehor(

--- a/src/test/kotlin/no/nav/hjelpemidler/soknad/db/db/SøknadStorePostgresTest.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/soknad/db/db/SøknadStorePostgresTest.kt
@@ -71,7 +71,7 @@ internal class SøknadStorePostgresTest {
                 )
                 assertEquals(
                     "Tilleggsinfo",
-                    hentSoknad?.søknadsdata?.hjelpemidler?.first()?.vilkarliste?.first()?.tilleggsInfo
+                    hentSoknad?.søknadsdata?.hjelpemidler?.first()?.vilkarliste?.first()?.tilleggsinfo
                 )
                 assertEquals(1, hentSoknad?.søknadsdata?.hjelpemidler?.first()?.tilbehorListe?.size)
                 assertEquals("654321", hentSoknad?.søknadsdata?.hjelpemidler?.first()?.tilbehorListe?.first()?.hmsnr)


### PR DESCRIPTION
Ref: https://trello.com/c/UyqyIEpf/424-bug-hm-formidler-og-hm-dinehjelpemidler-viser-ikke-riktige-vilk%C3%A5r-behov-p%C3%A5-sitteputer

Dette endrer så det er kun vilkår som er valgt som returneres fra APIet. Fikser også en skrivefeil i datamodellen: `tilleggsInfo -> tilleggsinfo`. Det er altså `tilleggsinfo` som brukes i klientene (hm-formidler og hm-dinehjelpemidler).