### PR TITLE
nye felt for begrunnelse av tilbehør

### DIFF
--- a/behovsmeldingsmodell/src/main/kotlin/no/nav/hjelpemidler/behovsmeldingsmodell/Behovsmelding.kt
+++ b/behovsmeldingsmodell/src/main/kotlin/no/nav/hjelpemidler/behovsmeldingsmodell/Behovsmelding.kt
@@ -450,6 +450,8 @@ data class Tilbehør(
     val navn: String,
     val automatiskGenerert: AutomatiskGenerertTilbehør?,
     val brukAvForslagsmotoren: BrukAvForslagsmotoren?,
+    val begrunnelse: String?,
+    val fritakFraBegrunnelseÅrsak: FritakFraBegrunnelseÅrsak?,
 )
 
 data class BrukAvForslagsmotoren(

--- a/behovsmeldingsmodell/src/main/kotlin/no/nav/hjelpemidler/behovsmeldingsmodell/Kodeverk.kt
+++ b/behovsmeldingsmodell/src/main/kotlin/no/nav/hjelpemidler/behovsmeldingsmodell/Kodeverk.kt
@@ -233,3 +233,8 @@ enum class AutomatiskGenerertTilbehør {
     @JsonProperty("Sittepute")
     SITTEPUTE,
 }
+
+enum class FritakFraBegrunnelseÅrsak {
+    ER_PÅ_BESTILLINGSORDNING,
+    IKKE_I_PILOT,
+}


### PR DESCRIPTION
@di0nys1us Kom gjerne med innspill her (både teknisk og grammatisk). Tanken er at alle tilbehør fremover vil enten ha en begrunnelse eller en fritakFraBegrunnelseÅrsak, og at Hotsak kan bruke fritakFraBegrunnelseÅrsak til å informere saksbehandler om hvorfor tilbehøret ikke er begrunnet.

I fremtiden vil det f.eks. kunne komme en ny enum-verdi ("ER_PÅ_UNNTAKSLISTE" e.l.) for enkle tilbehør som ikke trengs å begrunnes.