### PR TITLE
Lagre ny datamodell i ny kolonne

### DIFF
--- a/app/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SøknadForBruker.kt
+++ b/app/src/main/kotlin/no/nav/hjelpemidler/soknad/db/domain/SøknadForBruker.kt
@@ -40,7 +40,8 @@ class SøknadForBruker private constructor(
             journalpostId: String?,
             datoOpprettet: Date,
             datoOppdatert: Date,
-            søknad: JsonNode,
+            behovsmeldingJson: JsonNode,
+            behovsmeldingJsonV2: JsonNode?,
             status: BehovsmeldingStatus,
             fullmakt: Boolean,
             fnrBruker: String,
@@ -62,7 +63,7 @@ class SøknadForBruker private constructor(
                 fnrBruker = fnrBruker,
                 brukerpassbyttedata = when (behovsmeldingType) {
                     BehovsmeldingType.SØKNAD, BehovsmeldingType.BESTILLING, BehovsmeldingType.BYTTE -> null
-                    BehovsmeldingType.BRUKERPASSBYTTE -> jsonMapper.treeToValue<Brukerpassbytte>(søknad["brukerpassbytte"])
+                    BehovsmeldingType.BRUKERPASSBYTTE -> jsonMapper.treeToValue<Brukerpassbytte>(behovsmeldingJson["brukerpassbytte"])
                 },
                 er_digital = er_digital,
                 soknadGjelder = soknadGjelder,
@@ -71,9 +72,11 @@ class SøknadForBruker private constructor(
                 søknadType = søknadType,
                 valgteÅrsaker = valgteÅrsaker,
                 innsenderbehovsmelding = when (behovsmeldingType) {
-                    BehovsmeldingType.SØKNAD, BehovsmeldingType.BESTILLING, BehovsmeldingType.BYTTE -> tilInnsenderbehovsmeldingV2(
-                        jsonMapper.treeToValue<Behovsmelding>(søknad),
-                    )
+                    BehovsmeldingType.SØKNAD, BehovsmeldingType.BESTILLING, BehovsmeldingType.BYTTE ->
+                        behovsmeldingJsonV2?.let { jsonMapper.treeToValue<Innsenderbehovsmelding>(it) }
+                            ?: tilInnsenderbehovsmeldingV2(
+                                jsonMapper.treeToValue<Behovsmelding>(behovsmeldingJson),
+                            )
 
                     BehovsmeldingType.BRUKERPASSBYTTE -> null
                 },

--- a/app/src/main/kotlin/no/nav/hjelpemidler/soknad/db/store/RowExtensions.kt
+++ b/app/src/main/kotlin/no/nav/hjelpemidler/soknad/db/store/RowExtensions.kt
@@ -1,5 +1,6 @@
 package no.nav.hjelpemidler.soknad.db.store
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.hjelpemidler.behovsmeldingsmodell.BehovsmeldingId
 import no.nav.hjelpemidler.behovsmeldingsmodell.BehovsmeldingStatus
 import no.nav.hjelpemidler.behovsmeldingsmodell.BehovsmeldingType
@@ -9,6 +10,7 @@ import no.nav.hjelpemidler.behovsmeldingsmodell.sak.HotsakSak
 import no.nav.hjelpemidler.behovsmeldingsmodell.sak.HotsakSakId
 import no.nav.hjelpemidler.behovsmeldingsmodell.sak.InfotrygdSak
 import no.nav.hjelpemidler.behovsmeldingsmodell.sak.InfotrygdSakId
+import no.nav.hjelpemidler.behovsmeldingsmodell.v2.Innsenderbehovsmelding
 import no.nav.hjelpemidler.behovsmeldingsmodell.v2.mapping.tilInnsenderbehovsmeldingV2
 import no.nav.hjelpemidler.database.Row
 import no.nav.hjelpemidler.database.enum
@@ -17,6 +19,8 @@ import no.nav.hjelpemidler.database.json
 import no.nav.hjelpemidler.database.jsonOrNull
 import no.nav.hjelpemidler.domain.person.Fødselsnummer
 import no.nav.hjelpemidler.soknad.db.sak.tilVedtak
+
+private val log = KotlinLogging.logger {}
 
 fun Row.tilBehovsmeldingType(columnLabel: String = "behovsmeldingType"): BehovsmeldingType =
     enumOrNull<BehovsmeldingType>(columnLabel) ?: BehovsmeldingType.SØKNAD
@@ -43,12 +47,15 @@ fun Row.tilSøknad(): SøknadDto {
     )
 }
 
+fun Row.tilInnsenderbehovsmelding(): Innsenderbehovsmelding {
+    return jsonOrNull<Innsenderbehovsmelding>("data_v2")?.also { log.info { "Hentet innsenderbehovsmelding fra DATA_V2" } }
+        ?: tilInnsenderbehovsmeldingV2(json<no.nav.hjelpemidler.behovsmeldingsmodell.v1.Behovsmelding>("data")).also { log.info { "Mappet innsenderbehovsmelding fra DATA" } }
+}
+
 fun Row.tilInnsenderbehovsmeldingMetadataDto(): InnsenderbehovsmeldingMetadataDto {
     return InnsenderbehovsmeldingMetadataDto(
         behovsmeldingId = tilSøknadId(),
-        innsenderbehovsmelding = tilInnsenderbehovsmeldingV2(
-            json<no.nav.hjelpemidler.behovsmeldingsmodell.v1.Behovsmelding>("data"),
-        ),
+        innsenderbehovsmelding = tilInnsenderbehovsmelding(),
         fnrInnsender = Fødselsnummer(string("fnr_innsender")),
         behovsmeldingGjelder = string("soknad_gjelder"),
     )

--- a/app/src/main/kotlin/no/nav/hjelpemidler/soknad/db/store/RowExtensions.kt
+++ b/app/src/main/kotlin/no/nav/hjelpemidler/soknad/db/store/RowExtensions.kt
@@ -48,8 +48,8 @@ fun Row.tilSøknad(): SøknadDto {
 }
 
 fun Row.tilInnsenderbehovsmelding(): Innsenderbehovsmelding {
-    return jsonOrNull<Innsenderbehovsmelding>("data_v2")?.also { log.info { "Hentet innsenderbehovsmelding fra DATA_V2" } }
-        ?: tilInnsenderbehovsmeldingV2(json<no.nav.hjelpemidler.behovsmeldingsmodell.v1.Behovsmelding>("data")).also { log.info { "Mappet innsenderbehovsmelding fra DATA" } }
+    return jsonOrNull<Innsenderbehovsmelding>("data_v2")
+        ?: tilInnsenderbehovsmeldingV2(json<no.nav.hjelpemidler.behovsmeldingsmodell.v1.Behovsmelding>("data"))
 }
 
 fun Row.tilInnsenderbehovsmeldingMetadataDto(): InnsenderbehovsmeldingMetadataDto {

--- a/app/src/main/kotlin/no/nav/hjelpemidler/soknad/db/store/SøknadStoreInnsender.kt
+++ b/app/src/main/kotlin/no/nav/hjelpemidler/soknad/db/store/SøknadStoreInnsender.kt
@@ -3,13 +3,10 @@ package no.nav.hjelpemidler.soknad.db.store
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.hjelpemidler.behovsmeldingsmodell.BehovsmeldingStatus
 import no.nav.hjelpemidler.behovsmeldingsmodell.BehovsmeldingType
-import no.nav.hjelpemidler.behovsmeldingsmodell.v1.Behovsmelding
 import no.nav.hjelpemidler.behovsmeldingsmodell.v2.Innsenderbehovsmelding
-import no.nav.hjelpemidler.behovsmeldingsmodell.v2.mapping.tilInnsenderbehovsmeldingV2
 import no.nav.hjelpemidler.database.JdbcOperations
 import no.nav.hjelpemidler.database.Store
 import no.nav.hjelpemidler.database.enum
-import no.nav.hjelpemidler.database.json
 import no.nav.hjelpemidler.database.jsonOrNull
 import no.nav.hjelpemidler.database.sql.Sql
 import no.nav.hjelpemidler.soknad.db.rolle.InnsenderRolle
@@ -111,6 +108,7 @@ class SøknadStoreInnsender(private val tx: JdbcOperations) : Store {
                        soknad.created,
                        soknad.updated,
                        soknad.data,
+                       soknad.data_v2,
                        soknad.fnr_bruker,
                        soknad.navn_bruker,
                        status.status,
@@ -163,7 +161,7 @@ class SøknadStoreInnsender(private val tx: JdbcOperations) : Store {
                 fnrBruker = it.string("fnr_bruker"),
                 navnBruker = it.stringOrNull("navn_bruker"),
                 valgteÅrsaker = it.jsonOrNull<List<String>?>("arsaker") ?: emptyList(),
-                behovsmelding = tilInnsenderbehovsmeldingV2(it.json<Behovsmelding>("data")),
+                behovsmelding = it.tilInnsenderbehovsmelding(),
             )
         }
     }

--- a/app/src/main/resources/db/migration/V29__DATA_V2_COLUMN.sql
+++ b/app/src/main/resources/db/migration/V29__DATA_V2_COLUMN.sql
@@ -1,0 +1,2 @@
+-- Ny kolonne for v2 versjon av behovsmeldingsmodell
+ALTER TABLE V1_SOKNAD ADD COLUMN DATA_V2 JSONB;

--- a/behovsmeldingsmodell/src/main/kotlin/no/nav/hjelpemidler/behovsmeldingsmodell/Behovsmeldingsgrunnlag.kt
+++ b/behovsmeldingsmodell/src/main/kotlin/no/nav/hjelpemidler/behovsmeldingsmodell/Behovsmeldingsgrunnlag.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import no.nav.hjelpemidler.behovsmeldingsmodell.sak.Sakstilknytning
-import no.nav.hjelpemidler.behovsmeldingsmodell.v2.Innsenderbehovsmelding
 
 /**
  * Grunnlag for lagring av behovsmelding.
@@ -38,9 +37,12 @@ sealed interface Behovsmeldingsgrunnlag : TilknyttetSøknad {
         @JsonAlias("soknadGjelder")
         val behovsmeldingGjelder: String?,
         /**
-         * I overgangsfase vil vi kunne motta både behovsmelding og behvosmeldingV2
+         * I overgangsfase vil vi kunne motta både behovsmelding og behvosmeldingV2.
+         * Løs typing her, slik at vi slipper å oppdatere hm-soknadsbehandling hver gang
+         * behovsmeldingsmodellen oppdaterer seg. hm-soknadsbehandling skal uansett bare videre sende data.
+         * Typing av data i hm-soknad-api og hm-soknadsbehandling-db.
          */
-        val behovsmeldingV2: Innsenderbehovsmelding? = null,
+        val behovsmeldingV2: Map<String, Any?>? = null,
     ) : Behovsmeldingsgrunnlag {
         override val kilde: Kilde = Kilde.DIGITAL
         override val digital: Boolean = true


### PR DESCRIPTION
Når vi får inn den nye modellen så lagres den til DATA_V2. Gammel model lagres fremdeles i DATA som før. 
Lagrer dermed både ny og gammel model. På sikt kan vi mappe alle eksisterende saker fra DATA til DATA_V2 og slutte å bruke DATA, dersom vi er helt sikre på at vi har dekket alle behov, men inntil videre er planen å lagre begge parallellt. 
